### PR TITLE
feat: respect user's operating system theme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,3 +136,6 @@ set_target_properties(rme PROPERTIES CXX_STANDARD_REQUIRED ON)
 
 include_directories(${CMAKE_SOURCE_DIR}/source ${Boost_INCLUDE_DIRS} ${LibArchive_INCLUDE_DIRS} ${OPENGL_INCLUDE_DIR} ${GLUT_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIR} ${LUA_INCLUDE_DIR} ${LUA_INCLUDE_DIRS})
 target_link_libraries(rme ${wxWidgets_LIBRARIES} ${Boost_LIBRARIES} ${LibArchive_LIBRARIES} ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES} ${ZLIB_LIBRARIES} ${LIBS_TO_LINK})
+if(WIN32)
+	target_link_libraries(rme dwmapi)
+endif()

--- a/source/browse_tile_window.cpp
+++ b/source/browse_tile_window.cpp
@@ -66,14 +66,10 @@ void BrowseTileListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const
 
 	if (IsSelected(n)) {
 		item->select();
-		if (HasFocus()) {
-			dc.SetTextForeground(wxColor(0xFF, 0xFF, 0xFF));
-		} else {
-			dc.SetTextForeground(wxColor(0x00, 0x00, 0xFF));
-		}
+		dc.SetTextForeground(wxSystemSettings::GetColour(HasFocus() ? wxSYS_COLOUR_HIGHLIGHTTEXT : wxSYS_COLOUR_LISTBOXTEXT));
 	} else {
 		item->deselect();
-		dc.SetTextForeground(wxColor(0x00, 0x00, 0x00));
+		dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT));
 	}
 
 	wxString label;

--- a/source/common_windows.cpp
+++ b/source/common_windows.cpp
@@ -1147,13 +1147,9 @@ void FindDialogListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const
 		}
 
 		if (IsSelected(n)) {
-			if (HasFocus()) {
-				dc.SetTextForeground(wxColor(0xFF, 0xFF, 0xFF));
-			} else {
-				dc.SetTextForeground(wxColor(0x00, 0x00, 0xFF));
-			}
+			dc.SetTextForeground(wxSystemSettings::GetColour(HasFocus() ? wxSYS_COLOUR_HIGHLIGHTTEXT : wxSYS_COLOUR_LISTBOXTEXT));
 		} else {
-			dc.SetTextForeground(wxColor(0x00, 0x00, 0x00));
+			dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT));
 		}
 
 		dc.DrawText(wxstr(brushlist[n]->getName()), rect.GetX() + 40, rect.GetY() + 6);

--- a/source/dat_debug_view.cpp
+++ b/source/dat_debug_view.cpp
@@ -62,13 +62,9 @@ void DatDebugViewListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) con
 	}
 
 	if (IsSelected(n)) {
-		if (HasFocus()) {
-			dc.SetTextForeground(wxColor(0xFF, 0xFF, 0xFF));
-		} else {
-			dc.SetTextForeground(wxColor(0x00, 0x00, 0xFF));
-		}
+		dc.SetTextForeground(wxSystemSettings::GetColour(HasFocus() ? wxSYS_COLOUR_HIGHLIGHTTEXT : wxSYS_COLOUR_LISTBOXTEXT));
 	} else {
-		dc.SetTextForeground(wxColor(0x00, 0x00, 0x00));
+		dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT));
 	}
 
 	dc.DrawText(wxString() << n, rect.GetX() + 40, rect.GetY() + 6);

--- a/source/dcbutton.cpp
+++ b/source/dcbutton.cpp
@@ -96,23 +96,10 @@ void DCButton::OnPaint(wxPaintEvent& event) {
 		return;
 	}
 
-	static std::unique_ptr<wxPen> highlight_pen;
-	static std::unique_ptr<wxPen> dark_highlight_pen;
-	static std::unique_ptr<wxPen> light_shadow_pen;
-	static std::unique_ptr<wxPen> shadow_pen;
-
-	if (highlight_pen.get() == nullptr) {
-		highlight_pen.reset(newd wxPen(wxColor(0xFF, 0xFF, 0xFF), 1, wxSOLID));
-	}
-	if (dark_highlight_pen.get() == nullptr) {
-		dark_highlight_pen.reset(newd wxPen(wxColor(0xD4, 0xD0, 0xC8), 1, wxSOLID));
-	}
-	if (light_shadow_pen.get() == nullptr) {
-		light_shadow_pen.reset(newd wxPen(wxColor(0x80, 0x80, 0x80), 1, wxSOLID));
-	}
-	if (shadow_pen.get() == nullptr) {
-		shadow_pen.reset(newd wxPen(wxColor(0x40, 0x40, 0x40), 1, wxSOLID));
-	}
+	wxPen highlight_pen(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT), 1, wxSOLID);
+	wxPen dark_highlight_pen(wxSystemSettings::GetColour(wxSYS_COLOUR_3DLIGHT), 1, wxSOLID);
+	wxPen light_shadow_pen(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNSHADOW), 1, wxSOLID);
+	wxPen shadow_pen(wxSystemSettings::GetColour(wxSYS_COLOUR_3DDKSHADOW), 1, wxSOLID);
 
 	int size_x = 20, size_y = 20;
 
@@ -124,32 +111,32 @@ void DCButton::OnPaint(wxPaintEvent& event) {
 		size_y = 36;
 	}
 
-	pdc.SetBrush(*wxBLACK);
+	pdc.SetBrush(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE)));
 	pdc.DrawRectangle(0, 0, size_x, size_y);
 	if (type == DC_BTN_TOGGLE && GetValue()) {
-		pdc.SetPen(*shadow_pen);
+		pdc.SetPen(shadow_pen);
 		pdc.DrawLine(0, 0, size_x - 1, 0);
 		pdc.DrawLine(0, 1, 0, size_y - 1);
-		pdc.SetPen(*light_shadow_pen);
+		pdc.SetPen(light_shadow_pen);
 		pdc.DrawLine(1, 1, size_x - 2, 1);
 		pdc.DrawLine(1, 2, 1, size_y - 2);
-		pdc.SetPen(*dark_highlight_pen);
+		pdc.SetPen(dark_highlight_pen);
 		pdc.DrawLine(size_x - 2, 1, size_x - 2, size_y - 2);
 		pdc.DrawLine(1, size_y - 2, size_x - 1, size_y - 2);
-		pdc.SetPen(*highlight_pen);
+		pdc.SetPen(highlight_pen);
 		pdc.DrawLine(size_x - 1, 0, size_x - 1, size_y - 1);
 		pdc.DrawLine(0, size_y - 1, size_y, size_y - 1);
 	} else {
-		pdc.SetPen(*highlight_pen);
+		pdc.SetPen(highlight_pen);
 		pdc.DrawLine(0, 0, size_x - 1, 0);
 		pdc.DrawLine(0, 1, 0, size_y - 1);
-		pdc.SetPen(*dark_highlight_pen);
+		pdc.SetPen(dark_highlight_pen);
 		pdc.DrawLine(1, 1, size_x - 2, 1);
 		pdc.DrawLine(1, 2, 1, size_y - 2);
-		pdc.SetPen(*light_shadow_pen);
+		pdc.SetPen(light_shadow_pen);
 		pdc.DrawLine(size_x - 2, 1, size_x - 2, size_y - 2);
 		pdc.DrawLine(1, size_y - 2, size_x - 1, size_y - 2);
-		pdc.SetPen(*shadow_pen);
+		pdc.SetPen(shadow_pen);
 		pdc.DrawLine(size_x - 1, 0, size_x - 1, size_y - 1);
 		pdc.DrawLine(0, size_y - 1, size_y, size_y - 1);
 	}

--- a/source/lua/lua_dialog.cpp
+++ b/source/lua/lua_dialog.cpp
@@ -1007,7 +1007,7 @@ LuaDialog* LuaDialog::color(sol::table options) {
 	std::string id = options.get_or(std::string("id"), "color_"s + std::to_string(widgets.size()));
 	std::string labelText = options.get_or(std::string("label"), ""s);
 
-	wxColour defaultColor = *wxBLACK;
+	wxColour defaultColor = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
 	if (options["color"].valid()) {
 		sol::table c = options["color"];
 		int r = c.get_or(std::string("red"), c.get_or(1, 0));

--- a/source/lua/lua_scripts_window.cpp
+++ b/source/lua/lua_scripts_window.cpp
@@ -118,8 +118,8 @@ void LuaScriptsWindow::BuildUI() {
 	// Set monospace font for console
 	wxFont consoleFont(9, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
 	console_output->SetFont(consoleFont);
-	console_output->SetBackgroundColour(wxColour(30, 30, 30));
-	console_output->SetForegroundColour(wxColour(200, 200, 200));
+	console_output->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
+	console_output->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
 
 	mainSizer->Add(console_output, 1, wxEXPAND | wxALL, 2);
 
@@ -148,9 +148,8 @@ void LuaScriptsWindow::RefreshScriptList() {
 		// Store script index as item data
 		script_list->SetItemData(index, static_cast<long>(i));
 
-		// Color based on enabled state
 		if (!script->isEnabled()) {
-			script_list->SetItemTextColour(index, wxColour(128, 128, 128));
+			script_list->SetItemTextColour(index, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
 		}
 	}
 
@@ -169,12 +168,11 @@ void LuaScriptsWindow::LogMessage(const wxString& message, bool isError) {
 		return;
 	}
 
-	// Set color based on message type
 	wxTextAttr attr;
 	if (isError) {
-		attr.SetTextColour(wxColour(255, 100, 100)); // Red for errors
+		attr.SetTextColour(wxColour(255, 100, 100));
 	} else {
-		attr.SetTextColour(wxColour(200, 200, 200)); // Light gray for normal
+		attr.SetTextColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
 	}
 
 	console_output->SetDefaultStyle(attr);
@@ -211,9 +209,9 @@ void LuaScriptsWindow::UpdateScriptState(long index) {
 		script_list->SetItem(index, 0, script->isEnabled() ? "On" : "Off");
 
 		if (script->isEnabled()) {
-			script_list->SetItemTextColour(index, wxColour(0, 0, 0));
+			script_list->SetItemTextColour(index, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
 		} else {
-			script_list->SetItemTextColour(index, wxColour(128, 128, 128));
+			script_list->SetItemTextColour(index, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
 		}
 	}
 }

--- a/source/palette_brushlist.cpp
+++ b/source/palette_brushlist.cpp
@@ -601,13 +601,9 @@ void BrushListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const {
 		spr->DrawTo(&dc, SPRITE_SIZE_32x32, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
 	}
 	if (IsSelected(n)) {
-		if (HasFocus()) {
-			dc.SetTextForeground(wxColor(0xFF, 0xFF, 0xFF));
-		} else {
-			dc.SetTextForeground(wxColor(0x00, 0x00, 0xFF));
-		}
+		dc.SetTextForeground(wxSystemSettings::GetColour(HasFocus() ? wxSYS_COLOUR_HIGHLIGHTTEXT : wxSYS_COLOUR_LISTBOXTEXT));
 	} else {
-		dc.SetTextForeground(wxColor(0x00, 0x00, 0x00));
+		dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT));
 	}
 	dc.DrawText(wxstr(tileset->brushlist[n]->getName()), rect.GetX() + 40, rect.GetY() + 6);
 }

--- a/source/replace_items_window.cpp
+++ b/source/replace_items_window.cpp
@@ -133,6 +133,11 @@ void ReplaceItemsListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t index)
 		sprite1->DrawTo(&dc, SPRITE_SIZE_32x32, x + 4, y + 4, rect.GetWidth(), rect.GetHeight());
 		dc.DrawBitmap(m_arrow_bitmap, x + 38, y + 10, true);
 		sprite2->DrawTo(&dc, SPRITE_SIZE_32x32, x + 56, y + 4, rect.GetWidth(), rect.GetHeight());
+		if (IsSelected(index)) {
+			dc.SetTextForeground(wxSystemSettings::GetColour(HasFocus() ? wxSYS_COLOUR_HIGHLIGHTTEXT : wxSYS_COLOUR_LISTBOXTEXT));
+		} else {
+			dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT));
+		}
 		dc.DrawText(wxString::Format("Replace: %d With: %d", item.replaceId, item.withId), x + 104, y + 10);
 
 		if (item.complete) {
@@ -140,12 +145,6 @@ void ReplaceItemsListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t index)
 			dc.DrawBitmap(m_flag_bitmap, x + 70, y + 10, true);
 			dc.DrawText(wxString::Format("Total: %d", item.total), x, y + 10);
 		}
-	}
-
-	if (IsSelected(index)) {
-		dc.SetTextForeground(wxSystemSettings::GetColour(HasFocus() ? wxSYS_COLOUR_HIGHLIGHTTEXT : wxSYS_COLOUR_LISTBOXTEXT));
-	} else {
-		dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT));
 	}
 }
 

--- a/source/replace_items_window.cpp
+++ b/source/replace_items_window.cpp
@@ -143,13 +143,9 @@ void ReplaceItemsListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t index)
 	}
 
 	if (IsSelected(index)) {
-		if (HasFocus()) {
-			dc.SetTextForeground(wxColor(0xFF, 0xFF, 0xFF));
-		} else {
-			dc.SetTextForeground(wxColor(0x00, 0x00, 0xFF));
-		}
+		dc.SetTextForeground(wxSystemSettings::GetColour(HasFocus() ? wxSYS_COLOUR_HIGHLIGHTTEXT : wxSYS_COLOUR_LISTBOXTEXT));
 	} else {
-		dc.SetTextForeground(wxColor(0x00, 0x00, 0x00));
+		dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT));
 	}
 }
 

--- a/source/welcome_dialog.cpp
+++ b/source/welcome_dialog.cpp
@@ -204,7 +204,7 @@ RecentMapsPanel::RecentMapsPanel(wxWindow* parent, WelcomeDialog* dialog, const 
 RecentItem::RecentItem(wxWindow* parent, const wxColour& base_colour, const wxString& item_name) :
 	wxPanel(parent, wxID_ANY),
 	m_bg_colour(base_colour.ChangeLightness(95)),
-	m_bg_colour_hover(base_colour.ChangeLightness(88)),
+	m_bg_colour_hover(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT)),
 	m_text_colour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT)),
 	m_text_colour_hover(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT)),
 	m_title_text(wxFileNameFromPath(item_name)),

--- a/source/welcome_dialog.cpp
+++ b/source/welcome_dialog.cpp
@@ -218,7 +218,7 @@ RecentItem::RecentItem(wxWindow* parent, const wxColour& base_colour, const wxSt
 	Bind(wxEVT_LEAVE_WINDOW, &RecentItem::OnMouseLeave, this);
 }
 
-void RecentItem::OnPaint(wxPaintEvent& event) {
+void RecentItem::OnPaint(const wxPaintEvent& event) {
 	wxPaintDC dc(this);
 	wxColour bg = m_is_hover ? m_bg_colour_hover : m_bg_colour;
 	dc.SetBrush(wxBrush(bg));
@@ -229,8 +229,8 @@ void RecentItem::OnPaint(wxPaintEvent& event) {
 	int pad = FROM_DIP(this, 8);
 	dc.SetFont(GetFont().Bold());
 	dc.DrawText(m_title_text, pad, pad);
-	dc.SetFont(GetFont().Smaller());
 	wxSize titleSize = dc.GetTextExtent(m_title_text);
+	dc.SetFont(GetFont().Smaller());
 	dc.DrawText(m_item_text, pad, pad + titleSize.y + FROM_DIP(this, 2));
 }
 

--- a/source/welcome_dialog.h
+++ b/source/welcome_dialog.h
@@ -80,7 +80,7 @@ public:
 class RecentItem : public wxPanel {
 public:
 	RecentItem(wxWindow* parent, const wxColour& base_colour, const wxString& item_name);
-	void OnPaint(wxPaintEvent& event);
+	void OnPaint(const wxPaintEvent& event);
 	void OnMouseEnter(const wxMouseEvent& event);
 	void OnMouseLeave(const wxMouseEvent& event);
 	wxString GetText() const { return m_item_text; }

--- a/source/welcome_dialog.h
+++ b/source/welcome_dialog.h
@@ -80,19 +80,19 @@ public:
 class RecentItem : public wxPanel {
 public:
 	RecentItem(wxWindow* parent, const wxColour& base_colour, const wxString& item_name);
+	void OnPaint(wxPaintEvent& event);
 	void OnMouseEnter(const wxMouseEvent& event);
 	void OnMouseLeave(const wxMouseEvent& event);
-	void PropagateItemClicked(wxMouseEvent& event);
-	wxString GetText() {
-		return m_item_text;
-	};
+	wxString GetText() const { return m_item_text; }
 
 private:
+	wxColour m_bg_colour;
+	wxColour m_bg_colour_hover;
 	wxColour m_text_colour;
 	wxColour m_text_colour_hover;
-	wxStaticText* m_title;
-	wxStaticText* m_file_path;
+	wxString m_title_text;
 	wxString m_item_text;
+	bool m_is_hover;
 };
 
 #endif // WELCOME_DIALOG_H


### PR DESCRIPTION
Rather than always being in light mode, the UI now changes color based on the Windows theme settings.

Example:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ce522492-3f4a-45c7-97e4-3b7b9616efee" />

Set on Windows at:
<img width="697" height="504" alt="image" src="https://github.com/user-attachments/assets/c2fb0984-7399-487d-b542-73a443f840b2" />

Some icons are hardcoded (Brush Size / Tools under palette), but this is a significant improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows immersive dark mode support that follows system theme.
  * Interactive hover-driven recent items with custom painting.

* **Style**
  * UI updated to use system colors for lists, buttons, consoles, and dialogs for better theme consistency.

* **Bug Fixes / UI Improvements**
  * Improved hit-testing and rendering order for welcome screen items; more reliable list-item selection and focus visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->